### PR TITLE
Add support for RDMA, rename environment variables

### DIFF
--- a/src/main/java/io/hops/tensorflow/ApplicationMaster.java
+++ b/src/main/java/io/hops/tensorflow/ApplicationMaster.java
@@ -324,15 +324,15 @@ public class ApplicationMaster {
     
     allocationTimeout = Long.parseLong(cliParser.getOptionValue(ALLOCATION_TIMEOUT, "15")) * 1000;
     
-    environment.put("MEMORY", Integer.toString(containerMemory));
-    environment.put("VCORES", Integer.toString(containerVirtualCores));
-    environment.put("GPUS", Integer.toString(containerGPUs));
+    environment.put("YARNTF_MEMORY", Integer.toString(containerMemory));
+    environment.put("YARNTF_VCORES", Integer.toString(containerVirtualCores));
+    environment.put("YARNTF_GPUS", Integer.toString(containerGPUs));
     if (tfProtocol != null) {
-      environment.put("PROTOCOL", tfProtocol);
+      environment.put("YARNTF_PROTOCOL", tfProtocol);
     }
-    environment.put("WORKERS", Integer.toString(numWorkers));
-    environment.put("PSES", Integer.toString(numPses));
-    environment.put("HOME_DIR", FileSystem.get(conf).getHomeDirectory().toString());
+    environment.put("YARNTF_WORKERS", Integer.toString(numWorkers));
+    environment.put("YARNTF_PSES", Integer.toString(numPses));
+    environment.put("YARNTF_HOME", FileSystem.get(conf).getHomeDirectory().toString());
     environment.put("PYTHONUNBUFFERED", "true");
     
     DistributedCacheList distCacheList = null;
@@ -387,8 +387,8 @@ public class ApplicationMaster {
         port++;
       }
     }
-    environment.put("AM_ADDRESS", InetAddress.getLocalHost().getHostName() + ":" + port);
-    environment.put("APPLICATION_ID", appAttemptID.getApplicationId().toString());
+    environment.put("YARNTF_AM_ADDRESS", InetAddress.getLocalHost().getHostName() + ":" + port);
+    environment.put("YARNTF_APPLICATION_ID", appAttemptID.getApplicationId().toString());
     
     // Note: Credentials, Token, UserGroupInformation, DataOutputBuffer class
     // are marked as LimitedPrivate
@@ -717,13 +717,10 @@ public class ApplicationMaster {
       LOG.info("Setting up container launch container for containerid=" + container.getId());
       
       Map<String, String> envCopy = new HashMap<>(environment);
-      envCopy.put("JOB_NAME", jobName);
-      envCopy.put("TASK_INDEX", Integer.toString(taskIndex));
-      if (jobName.equals("worker")) {
-        envCopy.put("TB_DIR", "tensorboard_" + taskIndex);
-        if (tensorboard && taskIndex == 0) {
-          envCopy.put("TENSORBOARD", "true");
-        }
+      envCopy.put("YARNTF_JOB_NAME", jobName);
+      envCopy.put("YARNTF_TASK_INDEX", Integer.toString(taskIndex));
+      if (tensorboard && jobName.equals("worker")) {
+        envCopy.put("YARNTF_TENSORBOARD", "tensorboard_" + taskIndex);
       }
       
       // Set the executable command for the allocated container

--- a/src/main/java/io/hops/tensorflow/ApplicationMaster.java
+++ b/src/main/java/io/hops/tensorflow/ApplicationMaster.java
@@ -318,13 +318,19 @@ public class ApplicationMaster {
     numWorkers = Integer.parseInt(cliParser.getOptionValue(WORKERS, "1"));
     numPses = Integer.parseInt(cliParser.getOptionValue(PSES, "1"));
     numTotalContainers = numWorkers + numPses;
-    if (!(numWorkers > 0 && numPses > 0  || numWorkers == 1 && numPses == 0)) {
+    if (!(numWorkers > 0 && numPses > 0 || numWorkers == 1 && numPses == 0)) {
       throw new IllegalArgumentException("Invalid no. of workers or parameter server");
     }
     // requestPriority = Integer.parseInt(cliParser.getOptionValue(PRIORITY, "0"));
     
     allocationTimeout = Long.parseLong(cliParser.getOptionValue(ALLOCATION_TIMEOUT, "15")) * 1000;
     
+    environment.put("MEMORY", Integer.toString(containerMemory));
+    environment.put("VCORES", Integer.toString(containerVirtualCores));
+    environment.put("GPUS", Integer.toString(containerGPUs));
+    if (containerRDMA) {
+      environment.put("RDMA", "true");
+    }
     environment.put("WORKERS", Integer.toString(numWorkers));
     environment.put("PSES", Integer.toString(numPses));
     environment.put("HOME_DIR", FileSystem.get(conf).getHomeDirectory().toString());
@@ -506,10 +512,6 @@ public class ApplicationMaster {
     if (worker) {
       pri.setPriority(0); // worker: 0, ps: 1
       capability.setGPUs(containerGPUs);
-    }
-    
-    if (containerRDMA) {
-      LOG.warn("Trying to enable RDMA. Not yet implemented");
     }
     
     ContainerRequest request = new ContainerRequest(capability, null, null, pri);

--- a/src/main/java/io/hops/tensorflow/ApplicationMaster.java
+++ b/src/main/java/io/hops/tensorflow/ApplicationMaster.java
@@ -136,7 +136,6 @@ public class ApplicationMaster {
   private int containerGPUs;
   private String tfProtocol;
   // private int requestPriority;
-  private boolean tensorboard;
   
   // Timeout threshold for container allocation
   private final long appMasterStartTime = System.currentTimeMillis();
@@ -302,7 +301,7 @@ public class ApplicationMaster {
     }
     
     if (cliParser.hasOption(TENSORBOARD)) {
-      tensorboard = true;
+      environment.put("YARNTF_TENSORBOARD", "true");
     }
     
     if (envs.containsKey(Constants.YARNTFTIMELINEDOMAIN)) {
@@ -332,7 +331,7 @@ public class ApplicationMaster {
     }
     environment.put("YARNTF_WORKERS", Integer.toString(numWorkers));
     environment.put("YARNTF_PSES", Integer.toString(numPses));
-    environment.put("YARNTF_HOME", FileSystem.get(conf).getHomeDirectory().toString());
+    environment.put("YARNTF_HOME_DIR", FileSystem.get(conf).getHomeDirectory().toString());
     environment.put("PYTHONUNBUFFERED", "true");
     
     DistributedCacheList distCacheList = null;
@@ -719,8 +718,8 @@ public class ApplicationMaster {
       Map<String, String> envCopy = new HashMap<>(environment);
       envCopy.put("YARNTF_JOB_NAME", jobName);
       envCopy.put("YARNTF_TASK_INDEX", Integer.toString(taskIndex));
-      if (tensorboard && jobName.equals("worker")) {
-        envCopy.put("YARNTF_TENSORBOARD", "tensorboard_" + taskIndex);
+      if (jobName.equals("worker")) {
+        envCopy.put("YARNTF_TB_DIR", "tensorboard_" + taskIndex);
       }
       
       // Set the executable command for the allocated container

--- a/src/main/java/io/hops/tensorflow/ApplicationMaster.java
+++ b/src/main/java/io/hops/tensorflow/ApplicationMaster.java
@@ -79,7 +79,6 @@ import static io.hops.tensorflow.ApplicationMasterArguments.ENV;
 import static io.hops.tensorflow.ApplicationMasterArguments.HELP;
 import static io.hops.tensorflow.ApplicationMasterArguments.MAIN_RELATIVE;
 import static io.hops.tensorflow.ApplicationMasterArguments.MEMORY;
-// import static io.hops.tensorflow.ApplicationMasterArguments.PRIORITY;
 import static io.hops.tensorflow.ApplicationMasterArguments.PSES;
 import static io.hops.tensorflow.ApplicationMasterArguments.VCORES;
 import static io.hops.tensorflow.ApplicationMasterArguments.WORKERS;
@@ -87,9 +86,11 @@ import static io.hops.tensorflow.ApplicationMasterArguments.createOptions;
 import static io.hops.tensorflow.CommonArguments.ALLOCATION_TIMEOUT;
 import static io.hops.tensorflow.CommonArguments.ARGS;
 import static io.hops.tensorflow.CommonArguments.GPUS;
-import static io.hops.tensorflow.CommonArguments.RDMA;
+import static io.hops.tensorflow.CommonArguments.PROTOCOL;
 import static io.hops.tensorflow.CommonArguments.TENSORBOARD;
 import static io.hops.tensorflow.Constants.LOG4J_PATH;
+
+// import static io.hops.tensorflow.ApplicationMasterArguments.PRIORITY;
 
 public class ApplicationMaster {
   
@@ -133,7 +134,7 @@ public class ApplicationMaster {
   private int containerMemory;
   private int containerVirtualCores;
   private int containerGPUs;
-  private boolean containerRDMA;
+  private String tfProtocol;
   // private int requestPriority;
   private boolean tensorboard;
   
@@ -311,9 +312,7 @@ public class ApplicationMaster {
     containerMemory = Integer.parseInt(cliParser.getOptionValue(MEMORY, "1024"));
     containerVirtualCores = Integer.parseInt(cliParser.getOptionValue(VCORES, "1"));
     containerGPUs = Integer.parseInt(cliParser.getOptionValue(GPUS, "0"));
-    if (cliParser.hasOption(RDMA)) {
-      containerRDMA = true;
-    }
+    tfProtocol = cliParser.getOptionValue(PROTOCOL, null);
     
     numWorkers = Integer.parseInt(cliParser.getOptionValue(WORKERS, "1"));
     numPses = Integer.parseInt(cliParser.getOptionValue(PSES, "1"));
@@ -328,8 +327,8 @@ public class ApplicationMaster {
     environment.put("MEMORY", Integer.toString(containerMemory));
     environment.put("VCORES", Integer.toString(containerVirtualCores));
     environment.put("GPUS", Integer.toString(containerGPUs));
-    if (containerRDMA) {
-      environment.put("RDMA", "true");
+    if (tfProtocol != null) {
+      environment.put("PROTOCOL", tfProtocol);
     }
     environment.put("WORKERS", Integer.toString(numWorkers));
     environment.put("PSES", Integer.toString(numPses));

--- a/src/main/java/io/hops/tensorflow/Client.java
+++ b/src/main/java/io/hops/tensorflow/Client.java
@@ -79,6 +79,7 @@ import static io.hops.tensorflow.ClientArguments.AM_JAR;
 import static io.hops.tensorflow.ClientArguments.AM_MEMORY;
 import static io.hops.tensorflow.ClientArguments.AM_PRIORITY;
 import static io.hops.tensorflow.ClientArguments.AM_VCORES;
+import static io.hops.tensorflow.ClientArguments.APPLICATION_TIMEOUT;
 import static io.hops.tensorflow.ClientArguments.ARGS;
 import static io.hops.tensorflow.ClientArguments.ATTEMPT_FAILURES_VALIDITY_INTERVAL;
 import static io.hops.tensorflow.ClientArguments.CREATE;
@@ -95,18 +96,18 @@ import static io.hops.tensorflow.ClientArguments.MEMORY;
 import static io.hops.tensorflow.ClientArguments.MODIFY_ACLS;
 import static io.hops.tensorflow.ClientArguments.NAME;
 import static io.hops.tensorflow.ClientArguments.NODE_LABEL_EXPRESSION;
-// import static io.hops.tensorflow.ClientArguments.PRIORITY;
 import static io.hops.tensorflow.ClientArguments.PSES;
 import static io.hops.tensorflow.ClientArguments.QUEUE;
-import static io.hops.tensorflow.ClientArguments.APPLICATION_TIMEOUT;
 import static io.hops.tensorflow.ClientArguments.VCORES;
 import static io.hops.tensorflow.ClientArguments.VIEW_ACLS;
 import static io.hops.tensorflow.ClientArguments.WORKERS;
 import static io.hops.tensorflow.ClientArguments.createOptions;
 import static io.hops.tensorflow.CommonArguments.ALLOCATION_TIMEOUT;
 import static io.hops.tensorflow.CommonArguments.GPUS;
-import static io.hops.tensorflow.CommonArguments.RDMA;
+import static io.hops.tensorflow.CommonArguments.PROTOCOL;
 import static io.hops.tensorflow.CommonArguments.TENSORBOARD;
+
+// import static io.hops.tensorflow.ClientArguments.PRIORITY;
 
 public class Client {
   
@@ -136,7 +137,7 @@ public class Client {
   private int memory;
   private int vcores;
   private int gpus;
-  private boolean rdma;
+  private String protocol;
   private Map<String, String> environment = new HashMap<>(); // environment variables
   private boolean tensorboard;
   
@@ -314,9 +315,7 @@ public class Client {
     memory = Integer.parseInt(cliParser.getOptionValue(MEMORY, "1024"));
     vcores = Integer.parseInt(cliParser.getOptionValue(VCORES, "1"));
     gpus = Integer.parseInt(cliParser.getOptionValue(GPUS, "0"));
-    if (cliParser.hasOption(RDMA)) {
-      rdma = true;
-    }
+    protocol = cliParser.getOptionValue(PROTOCOL, null);
     
     numWorkers = Integer.parseInt(cliParser.getOptionValue(WORKERS, "1"));
     numPses = Integer.parseInt(cliParser.getOptionValue(PSES, "1"));
@@ -583,8 +582,8 @@ public class Client {
     vargs.add(newArg(MEMORY, String.valueOf(memory)));
     vargs.add(newArg(VCORES, String.valueOf(vcores)));
     vargs.add(newArg(GPUS, String.valueOf(gpus)));
-    if (rdma) {
-      vargs.add("--" + RDMA);
+    if (protocol != null) {
+      vargs.add(newArg(PROTOCOL, protocol));
     }
     // vargs.add(newArg(PRIORITY, String.valueOf(priority)));
     vargs.add(newArg(ALLOCATION_TIMEOUT, String.valueOf(allocationTimeout / 1000)));

--- a/src/main/java/io/hops/tensorflow/CommonArguments.java
+++ b/src/main/java/io/hops/tensorflow/CommonArguments.java
@@ -51,7 +51,7 @@ public abstract class CommonArguments {
     opts.addOption(MEMORY, true, "Amount of memory in MB to be requested to run the TF application");
     opts.addOption(VCORES, true, "Amount of virtual cores to be requested to run the TF application");
     opts.addOption(GPUS, true, "Amount of GPUs for each TF application container");
-    opts.addOption(RDMA, false, "Use RDMA protocol for TF application");
+    opts.addOption(RDMA, false, "Use RDMA protocol for TF application. Does not allocate needed resources");
     // opts.addOption(PRIORITY, true, "Priority for the Python application containers");
     opts.addOption(ALLOCATION_TIMEOUT, true, "Container allocation timeout in seconds");
     

--- a/src/main/java/io/hops/tensorflow/CommonArguments.java
+++ b/src/main/java/io/hops/tensorflow/CommonArguments.java
@@ -51,7 +51,7 @@ public abstract class CommonArguments {
     opts.addOption(MEMORY, true, "Amount of memory in MB to be requested to run the TF application");
     opts.addOption(VCORES, true, "Amount of virtual cores to be requested to run the TF application");
     opts.addOption(GPUS, true, "Amount of GPUs for each TF application container");
-    opts.addOption(RDMA, false, "Enable RDMA (dummy flag: not yet implemented!)"); // TODO: after impl, update desc
+    opts.addOption(RDMA, false, "Use RDMA protocol for TF application");
     // opts.addOption(PRIORITY, true, "Priority for the Python application containers");
     opts.addOption(ALLOCATION_TIMEOUT, true, "Container allocation timeout in seconds");
     

--- a/src/main/java/io/hops/tensorflow/CommonArguments.java
+++ b/src/main/java/io/hops/tensorflow/CommonArguments.java
@@ -31,7 +31,7 @@ public abstract class CommonArguments {
   public static final String MEMORY = "memory";
   public static final String VCORES = "vcores";
   public static final String GPUS = "gpus";
-  public static final String RDMA = "rdma";
+  public static final String PROTOCOL = "protocol";
   // public static final String PRIORITY = "priority";
   public static final String ALLOCATION_TIMEOUT = "allocation_timeout";
   
@@ -51,7 +51,7 @@ public abstract class CommonArguments {
     opts.addOption(MEMORY, true, "Amount of memory in MB to be requested to run the TF application");
     opts.addOption(VCORES, true, "Amount of virtual cores to be requested to run the TF application");
     opts.addOption(GPUS, true, "Amount of GPUs for each TF application container");
-    opts.addOption(RDMA, false, "Use RDMA protocol for TF application. Does not allocate needed resources");
+    opts.addOption(PROTOCOL, true, "Specify the protocol parameter for tf.train.Server()");
     // opts.addOption(PRIORITY, true, "Priority for the Python application containers");
     opts.addOption(ALLOCATION_TIMEOUT, true, "Container allocation timeout in seconds");
     

--- a/src/test/java/io/hops/tensorflow/TestPyModule.java
+++ b/src/test/java/io/hops/tensorflow/TestPyModule.java
@@ -60,12 +60,13 @@ public class TestPyModule {
     int regs = 0;
     String line = "";
     while ((line = reader.readLine())!= null) {
+      System.out.println(line);
       if (line.contains("registered: True")) {
         regs += 1;
       }
     }
     Assert.assertEquals(3, regs);
     Assert.assertEquals(3, server.getClusterSpec().size());
-    Assert.assertEquals(3, server.getTensorBoards().size());
+    Assert.assertEquals(1, server.getTensorBoards().size());
   }
 }

--- a/src/test/java/io/hops/tensorflow/TestYarnTF.java
+++ b/src/test/java/io/hops/tensorflow/TestYarnTF.java
@@ -68,7 +68,7 @@ public class TestYarnTF extends TestCluster {
   
     Assert.assertTrue(TestUtils.dumpAllRemoteContainersLogs(yarnCluster, appId));
     Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "Number of arguments: 9"));
-    Assert.assertEquals(4, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "YARNTF_TENSORBOARD=tensorboard_"));
+    Assert.assertEquals(4, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "YARNTF_TB_DIR=tensorboard_"));
     // Thread.sleep(5000);
     // TestUtils.dumpAllAggregatedContainersLogs(yarnCluster, appId);
   }

--- a/src/test/java/io/hops/tensorflow/TestYarnTF.java
+++ b/src/test/java/io/hops/tensorflow/TestYarnTF.java
@@ -34,6 +34,7 @@ import static io.hops.tensorflow.ClientArguments.MEMORY;
 import static io.hops.tensorflow.ClientArguments.PSES;
 import static io.hops.tensorflow.ClientArguments.VCORES;
 import static io.hops.tensorflow.ClientArguments.WORKERS;
+import static io.hops.tensorflow.CommonArguments.PROTOCOL;
 import static io.hops.tensorflow.CommonArguments.TENSORBOARD;
 
 public class TestYarnTF extends TestCluster {
@@ -52,6 +53,7 @@ public class TestYarnTF extends TestCluster {
         "--" + VCORES, "1",
         "--" + MAIN, mainPath,
         "--" + ARGS, "--images mnist/tfr/train --format tfr --mode train --model mnist_model",
+        "--" + PROTOCOL, "grpc+verbs"
     };
     
     LOG.info("Initializing yarntf Client");
@@ -66,6 +68,7 @@ public class TestYarnTF extends TestCluster {
     
     Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "Number of arguments: 9"));
     Assert.assertEquals(4, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "TB_DIR=tensorboard_"));
+    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "PROTOCOL=grpc+verbs"));
     Assert.assertTrue(TestUtils.dumpAllRemoteContainersLogs(yarnCluster, appId));
     // Thread.sleep(5000);
     // TestUtils.dumpAllAggregatedContainersLogs(yarnCluster, appId);
@@ -97,5 +100,6 @@ public class TestYarnTF extends TestCluster {
     LOG.info("Client run completed. Result=" + result);
     
     Assert.assertEquals(2, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "hello, from baz"));
+    Assert.assertEquals(0, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "PROTOCOL="));
   }
 }

--- a/src/test/java/io/hops/tensorflow/TestYarnTF.java
+++ b/src/test/java/io/hops/tensorflow/TestYarnTF.java
@@ -67,8 +67,9 @@ public class TestYarnTF extends TestCluster {
     LOG.info("Client run completed. Result=" + result);
     
     Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "Number of arguments: 9"));
-    Assert.assertEquals(4, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "TB_DIR=tensorboard_"));
-    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "PROTOCOL=grpc+verbs"));
+    Assert.assertEquals(1, TestUtils.verifyContainerLog(yarnCluster, 5, null, true,
+        "YARNTF_TENSORBOARD=tensorboard_"));
+    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "YARNTF_PROTOCOL=grpc+verbs"));
     Assert.assertTrue(TestUtils.dumpAllRemoteContainersLogs(yarnCluster, appId));
     // Thread.sleep(5000);
     // TestUtils.dumpAllAggregatedContainersLogs(yarnCluster, appId);
@@ -100,6 +101,6 @@ public class TestYarnTF extends TestCluster {
     LOG.info("Client run completed. Result=" + result);
     
     Assert.assertEquals(2, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "hello, from baz"));
-    Assert.assertEquals(0, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "PROTOCOL="));
+    Assert.assertEquals(0, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "YARNTF_PROTOCOL="));
   }
 }

--- a/src/test/java/io/hops/tensorflow/TestYarnTF.java
+++ b/src/test/java/io/hops/tensorflow/TestYarnTF.java
@@ -53,7 +53,7 @@ public class TestYarnTF extends TestCluster {
         "--" + VCORES, "1",
         "--" + MAIN, mainPath,
         "--" + ARGS, "--images mnist/tfr/train --format tfr --mode train --model mnist_model",
-        "--" + PROTOCOL, "grpc+verbs"
+        "--" + TENSORBOARD
     };
     
     LOG.info("Initializing yarntf Client");
@@ -65,12 +65,10 @@ public class TestYarnTF extends TestCluster {
     
     boolean result = client.monitorApplication(appId);
     LOG.info("Client run completed. Result=" + result);
-    
-    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "Number of arguments: 9"));
-    Assert.assertEquals(1, TestUtils.verifyContainerLog(yarnCluster, 5, null, true,
-        "YARNTF_TENSORBOARD=tensorboard_"));
-    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "YARNTF_PROTOCOL=grpc+verbs"));
+  
     Assert.assertTrue(TestUtils.dumpAllRemoteContainersLogs(yarnCluster, appId));
+    Assert.assertEquals(5, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "Number of arguments: 9"));
+    Assert.assertEquals(4, TestUtils.verifyContainerLog(yarnCluster, 5, null, true, "YARNTF_TENSORBOARD=tensorboard_"));
     // Thread.sleep(5000);
     // TestUtils.dumpAllAggregatedContainersLogs(yarnCluster, appId);
   }
@@ -87,7 +85,8 @@ public class TestYarnTF extends TestCluster {
         "--" + MEMORY, "256",
         "--" + VCORES, "1",
         "--" + FILES, extraDepPy + "," + extraDepZip,
-        "--" + MAIN, mainPath
+        "--" + MAIN, mainPath,
+        "--" + PROTOCOL, "grpc+verbs"
     };
     
     LOG.info("Initializing yarntf Client");
@@ -101,6 +100,6 @@ public class TestYarnTF extends TestCluster {
     LOG.info("Client run completed. Result=" + result);
     
     Assert.assertEquals(2, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "hello, from baz"));
-    Assert.assertEquals(0, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "YARNTF_PROTOCOL="));
+    Assert.assertEquals(2, TestUtils.verifyContainerLog(yarnCluster, 2, null, true, "YARNTF_PROTOCOL=grpc+verbs"));
   }
 }

--- a/src/test/resources/bar.py
+++ b/src/test/resources/bar.py
@@ -4,4 +4,4 @@ import baz
 
 
 def hello_from_baz():
-    baz.hello()
+  baz.hello()

--- a/src/test/resources/create_cluster_server.py
+++ b/src/test/resources/create_cluster_server.py
@@ -10,4 +10,7 @@ print('Argument list: ' + str(sys.argv))
 cluster, server = yarntf.createClusterServer()
 
 if 'TB_DIR' in os.environ:
-    print('TB_DIR=' + os.environ['TB_DIR'])
+  print('TB_DIR=' + os.environ['TB_DIR'])
+
+if 'PROTOCOL' in os.environ:
+  print('PROTOCOL=' + os.environ['PROTOCOL'])

--- a/src/test/resources/create_cluster_server.py
+++ b/src/test/resources/create_cluster_server.py
@@ -11,6 +11,3 @@ cluster, server = yarntf.createClusterServer()
 
 if 'YARNTF_TENSORBOARD' in os.environ:
   print('YARNTF_TENSORBOARD=' + os.environ['YARNTF_TENSORBOARD'])
-
-if 'YARNTF_PROTOCOL' in os.environ:
-  print('YARNTF_PROTOCOL=' + os.environ['YARNTF_PROTOCOL'])

--- a/src/test/resources/create_cluster_server.py
+++ b/src/test/resources/create_cluster_server.py
@@ -9,5 +9,5 @@ print('Argument list: ' + str(sys.argv))
 
 cluster, server = yarntf.createClusterServer()
 
-if 'YARNTF_TENSORBOARD' in os.environ:
-  print('YARNTF_TENSORBOARD=' + os.environ['YARNTF_TENSORBOARD'])
+if 'YARNTF_TB_DIR' in os.environ:
+  print('YARNTF_TB_DIR=' + os.environ['YARNTF_TB_DIR'])

--- a/src/test/resources/create_cluster_server.py
+++ b/src/test/resources/create_cluster_server.py
@@ -9,8 +9,8 @@ print('Argument list: ' + str(sys.argv))
 
 cluster, server = yarntf.createClusterServer()
 
-if 'TB_DIR' in os.environ:
-  print('TB_DIR=' + os.environ['TB_DIR'])
+if 'YARNTF_TENSORBOARD' in os.environ:
+  print('YARNTF_TENSORBOARD=' + os.environ['YARNTF_TENSORBOARD'])
 
-if 'PROTOCOL' in os.environ:
-  print('PROTOCOL=' + os.environ['PROTOCOL'])
+if 'YARNTF_PROTOCOL' in os.environ:
+  print('YARNTF_PROTOCOL=' + os.environ['YARNTF_PROTOCOL'])

--- a/src/test/resources/factory_test.py
+++ b/src/test/resources/factory_test.py
@@ -8,12 +8,12 @@ threads = []
 
 os.environ['TENSORBOARD'] = 'true'
 for i in range(0, 3):
-    os.environ['TB_DIR'] = 'tensorboard_' + str(i)
-    thread = threading.Thread(target=yarntf.createClusterSpec,
-                              args=('localhost:50052', '(appId)', 'worker', i))
-    thread.start()
-    threads.append(thread)
-    time.sleep(2)
+  os.environ['TB_DIR'] = 'tensorboard_' + str(i)
+  thread = threading.Thread(target=yarntf.createClusterSpec,
+                            args=('localhost:50052', '(appId)', 'worker', i))
+  thread.start()
+  threads.append(thread)
+  time.sleep(2)
 
 for thread in threads:
-    thread.join()
+  thread.join()

--- a/src/test/resources/factory_test.py
+++ b/src/test/resources/factory_test.py
@@ -8,8 +8,9 @@ import yarntf
 
 threads = []
 
+os.environ['YARNTF_TENSORBOARD'] = 'true'
 for i in range(0, 3):
-  os.environ['YARNTF_TENSORBOARD'] = 'tensorboard_' + str(i)
+  os.environ['YARNTF_TB_DIR'] = 'tensorboard_' + str(i)
   thread = threading.Thread(target=yarntf.createClusterSpec,
                             args=('localhost:50052', '(appId)', 'worker', i))
   thread.start()

--- a/src/test/resources/factory_test.py
+++ b/src/test/resources/factory_test.py
@@ -1,3 +1,5 @@
+"""Assumes ClusterSpecGeneratorServer is running"""
+
 import os
 import threading
 import time
@@ -6,9 +8,8 @@ import yarntf
 
 threads = []
 
-os.environ['TENSORBOARD'] = 'true'
 for i in range(0, 3):
-  os.environ['TB_DIR'] = 'tensorboard_' + str(i)
+  os.environ['YARNTF_TENSORBOARD'] = 'tensorboard_' + str(i)
   thread = threading.Thread(target=yarntf.createClusterSpec,
                             args=('localhost:50052', '(appId)', 'worker', i))
   thread.start()

--- a/src/test/resources/foo.py
+++ b/src/test/resources/foo.py
@@ -1,5 +1,10 @@
 from __future__ import print_function
 
+import os
+
 import bar
 
 bar.hello_from_baz()
+
+if 'YARNTF_PROTOCOL' in os.environ:
+  print('YARNTF_PROTOCOL=' + os.environ['YARNTF_PROTOCOL'])

--- a/yarntf/examples/cifar10/cifar10_multi_gpu_train.py
+++ b/yarntf/examples/cifar10/cifar10_multi_gpu_train.py
@@ -216,7 +216,7 @@ def train():
     # Start the queue runners.
     tf.train.start_queue_runners(sess=sess)
 
-    summary_writer = tf.summary.FileWriter(os.environ["TB_DIR"], sess.graph)
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], sess.graph)
 
     for step in xrange(FLAGS.max_steps):
       start_time = time.time()

--- a/yarntf/examples/cifar10/cifar10_multi_gpu_train.py
+++ b/yarntf/examples/cifar10/cifar10_multi_gpu_train.py
@@ -216,7 +216,7 @@ def train():
     # Start the queue runners.
     tf.train.start_queue_runners(sess=sess)
 
-    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], sess.graph)
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TB_DIR"], sess.graph)
 
     for step in xrange(FLAGS.max_steps):
       start_time = time.time()

--- a/yarntf/examples/mnist/mnist.py
+++ b/yarntf/examples/mnist/mnist.py
@@ -23,14 +23,14 @@ def print_log(worker_id, arg):
 
 
 def hdfs_path(relative_path):
-  return os.environ["HOME_DIR"] + "/" + relative_path
+  return os.environ["YARNTF_HOME"] + "/" + relative_path
 
 
 def main(args):
-  job_name = os.environ["JOB_NAME"]
-  task_index = int(os.environ["TASK_INDEX"])
-  num_workers = int(os.environ["WORKERS"])
-  num_pses = int(os.environ["PSES"])
+  job_name = os.environ["YARNTF_JOB_NAME"]
+  task_index = int(os.environ["YARNTF_TASK_INDEX"])
+  num_workers = int(os.environ["YARNTF_WORKERS"])
+  num_pses = int(os.environ["YARNTF_PSES"])
   worker_id = job_name + str(task_index)
 
   # Parameters
@@ -165,7 +165,7 @@ def main(args):
     # Create a "supervisor", which oversees the training process and stores model state into HDFS
     logdir = hdfs_path(args.model)
     print("tensorflow model path: {0}".format(logdir))
-    summary_writer = tf.summary.FileWriter(os.environ["TB_DIR"], graph=tf.get_default_graph())
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], graph=tf.get_default_graph())
 
     if args.mode == "train":
       sv = tf.train.Supervisor(is_chief=(task_index == 0),

--- a/yarntf/examples/mnist/mnist.py
+++ b/yarntf/examples/mnist/mnist.py
@@ -23,7 +23,7 @@ def print_log(worker_id, arg):
 
 
 def hdfs_path(relative_path):
-  return os.environ["YARNTF_HOME"] + "/" + relative_path
+  return os.environ["YARNTF_HOME_DIR"] + "/" + relative_path
 
 
 def main(args):
@@ -165,7 +165,7 @@ def main(args):
     # Create a "supervisor", which oversees the training process and stores model state into HDFS
     logdir = hdfs_path(args.model)
     print("tensorflow model path: {0}".format(logdir))
-    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], graph=tf.get_default_graph())
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TB_DIR"], graph=tf.get_default_graph())
 
     if args.mode == "train":
       sv = tf.train.Supervisor(is_chief=(task_index == 0),

--- a/yarntf/examples/slim/train_image_classifier.py
+++ b/yarntf/examples/slim/train_image_classifier.py
@@ -370,10 +370,10 @@ def main(_):
   cluster, server = yarntf.createClusterServer()
 
   # overwrite flags
-  FLAGS.job_name = os.environ["JOB_NAME"]
-  FLAGS.task = int(os.environ["TASK_INDEX"])
-  FLAGS.worker_replicas = int(os.environ["WORKERS"])
-  FLAGS.num_ps_tasks = int(os.environ["PSES"])
+  FLAGS.job_name = os.environ["YARNTF_JOB_NAME"]
+  FLAGS.task = int(os.environ["YARNTF_TASK_INDEX"])
+  FLAGS.worker_replicas = int(os.environ["YARNTF_WORKERS"])
+  FLAGS.num_ps_tasks = int(os.environ["YARNTF_PSES"])
   FLAGS.master = server.target
 
   if FLAGS.job_name == "ps":
@@ -556,7 +556,7 @@ def train():
 
     # Merge all summaries together.
     summary_op = tf.summary.merge(list(summaries), name='summary_op')
-    summary_writer = tf.summary.FileWriter(os.environ["TB_DIR"], graph=tf.get_default_graph())
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], graph=tf.get_default_graph())
 
 
     ###########################

--- a/yarntf/examples/slim/train_image_classifier.py
+++ b/yarntf/examples/slim/train_image_classifier.py
@@ -556,7 +556,7 @@ def train():
 
     # Merge all summaries together.
     summary_op = tf.summary.merge(list(summaries), name='summary_op')
-    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TENSORBOARD"], graph=tf.get_default_graph())
+    summary_writer = tf.summary.FileWriter(os.environ["YARNTF_TB_DIR"], graph=tf.get_default_graph())
 
 
     ###########################

--- a/yarntf/setup.py
+++ b/yarntf/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
   name='tfyarn',
-  version='0.0.3.dev1',
+  version='0.0.3.dev2',
   description='Easy distributed TensorFlow on Hops Hadoop',
   long_description=long_description,
   url='https://github.com/hopshadoop/hops-tensorflow',

--- a/yarntf/setup.py
+++ b/yarntf/setup.py
@@ -8,8 +8,8 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
   long_description = f.read()
 
 setup(
-  name='tfyarn',
-  version='0.0.3.dev2',
+  name='yarntf',
+  version='0.0.3.dev3',
   description='Easy distributed TensorFlow on Hops Hadoop',
   long_description=long_description,
   url='https://github.com/hopshadoop/hops-tensorflow',

--- a/yarntf/setup.py
+++ b/yarntf/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
   long_description = f.read()
 
 setup(
-  name='yarntf',
+  name='tfyarn',
   version='0.0.3.dev1',
   description='Easy distributed TensorFlow on Hops Hadoop',
   long_description=long_description,

--- a/yarntf/setup.py
+++ b/yarntf/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
   name='yarntf',
-  version='0.0.3.dev1-SNAPSHOT',
+  version='0.0.3.dev1',
   description='Easy distributed TensorFlow on Hops Hadoop',
   long_description=long_description,
   url='https://github.com/hopshadoop/hops-tensorflow',
@@ -17,7 +17,7 @@ setup(
   author_email='tobias@johansson.xyz',
   license='Apache License 2.0',
   classifiers=[
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Libraries',
     'License :: OSI Approved :: Apache Software License',

--- a/yarntf/tests/factory_test.py
+++ b/yarntf/tests/factory_test.py
@@ -9,9 +9,8 @@ def cluster_spec_test():
   """Assumes ClusterSpecGeneratorServer is running"""
   threads = []
 
-  os.environ['TENSORBOARD'] = 'true'
   for i in range(0, 3):
-    os.environ['TB_DIR'] = 'tensorboard_' + str(i)
+    os.environ['YARNTF_TENSORBOARD'] = 'tensorboard_' + str(i)
     thread = threading.Thread(target=yarntf.createClusterSpec,
                               args=('localhost:50052', '(appId)', 'worker', i))
     thread.start()

--- a/yarntf/tests/factory_test.py
+++ b/yarntf/tests/factory_test.py
@@ -9,8 +9,9 @@ def cluster_spec_test():
   """Assumes ClusterSpecGeneratorServer is running"""
   threads = []
 
+  os.environ['YARNTF_TENSORBOARD'] = 'true'
   for i in range(0, 3):
-    os.environ['YARNTF_TENSORBOARD'] = 'tensorboard_' + str(i)
+    os.environ['YARNTF_TB_DIR'] = 'tensorboard_' + str(i)
     thread = threading.Thread(target=yarntf.createClusterSpec,
                               args=('localhost:50052', '(appId)', 'worker', i))
     thread.start()

--- a/yarntf/yarntf/factory.py
+++ b/yarntf/yarntf/factory.py
@@ -26,12 +26,13 @@ def createClusterSpec(am_address, application_id, job_name, task_index):
   client = ClusterSpecGeneratorClient(am_address)
 
   tb_port = -1
-  if 'TENSORBOARD' in os.environ and os.environ['TENSORBOARD'] == 'true':
+  if 'YARNTF_TENSORBOARD' in os.environ and task_index == 0:
     tb_s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     tb_s.bind(('', 0))
     tb_port = tb_s.getsockname()[1]
     tb_s.close()
-    subprocess.Popen(['tensorboard', '--logdir=' + os.environ['TB_DIR'], '--port=' + str(tb_port), '--debug'])
+    subprocess.Popen(
+      ['tensorboard', '--logdir=' + os.environ['YARNTF_TENSORBOARD'], '--port=' + str(tb_port), '--debug'])
 
   host = socket.gethostname()
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -82,13 +83,13 @@ def createClusterServer():
 
    Returns: A generated `ClusterSpec` for the application, and a `Server` instantiated from the same `ClusterSpec`.
   """
-  am_address = os.environ['AM_ADDRESS']
-  application_id = os.environ['APPLICATION_ID']
-  job_name = os.environ['JOB_NAME']
-  task_index = int(os.environ['TASK_INDEX'])
+  am_address = os.environ['YARNTF_AM_ADDRESS']
+  application_id = os.environ['YARNTF_APPLICATION_ID']
+  job_name = os.environ['YARNTF_JOB_NAME']
+  task_index = int(os.environ['YARNTF_TASK_INDEX'])
   cluster = createClusterSpec(am_address, application_id, job_name, task_index)
-  if 'PROTOCOL' in os.environ:
-    server = tf.train.Server(cluster, job_name=job_name, task_index=task_index, protocol=os.environ['PROTOCOL'])
+  if 'YARNTF_PROTOCOL' in os.environ:
+    server = tf.train.Server(cluster, job_name=job_name, task_index=task_index, protocol=os.environ['YARNTF_PROTOCOL'])
   else:
     server = tf.train.Server(cluster, job_name=job_name, task_index=task_index)
   return cluster, server

--- a/yarntf/yarntf/factory.py
+++ b/yarntf/yarntf/factory.py
@@ -32,7 +32,7 @@ def createClusterSpec(am_address, application_id, job_name, task_index):
     tb_port = tb_s.getsockname()[1]
     tb_s.close()
     subprocess.Popen(
-      ['tensorboard', '--logdir=' + os.environ['YARNTF_TENSORBOARD'], '--port=' + str(tb_port), '--debug'])
+      ['tensorboard', '--logdir=' + os.environ['YARNTF_TB_DIR'], '--port=' + str(tb_port), '--debug'])
 
   host = socket.gethostname()
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/yarntf/yarntf/factory.py
+++ b/yarntf/yarntf/factory.py
@@ -26,7 +26,7 @@ def createClusterSpec(am_address, application_id, job_name, task_index):
   client = ClusterSpecGeneratorClient(am_address)
 
   tb_port = -1
-  if 'YARNTF_TENSORBOARD' in os.environ and task_index == 0:
+  if 'YARNTF_TENSORBOARD' in os.environ and job_name == 'worker' and task_index == 0:
     tb_s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     tb_s.bind(('', 0))
     tb_port = tb_s.getsockname()[1]

--- a/yarntf/yarntf/factory.py
+++ b/yarntf/yarntf/factory.py
@@ -87,4 +87,8 @@ def createClusterServer():
   job_name = os.environ['JOB_NAME']
   task_index = int(os.environ['TASK_INDEX'])
   cluster = createClusterSpec(am_address, application_id, job_name, task_index)
-  return cluster, tf.train.Server(cluster, job_name=job_name, task_index=task_index)
+  if 'PROTOCOL' in os.environ:
+    server = tf.train.Server(cluster, job_name=job_name, task_index=task_index, protocol=os.environ['PROTOCOL'])
+  else:
+    server = tf.train.Server(cluster, job_name=job_name, task_index=task_index)
+  return cluster, server


### PR DESCRIPTION
- Add common arg `protocol` to Client/AM that sets `tf.train.Server()`
- Add prefix `YARNTF` to all custom environment variables